### PR TITLE
setTypeFace method for MaterialTab host

### DIFF
--- a/MaterialTabsModule/src/main/java/it/neokree/materialtabs/MaterialTab.java
+++ b/MaterialTabsModule/src/main/java/it/neokree/materialtabs/MaterialTab.java
@@ -95,7 +95,11 @@ public class MaterialTab implements View.OnTouchListener {
 		iconColor = Color.WHITE; // and icon
 	}
 	
-	
+	public void setTypeFace(Typeface typeFace) {
+	        if(text != null) {
+	            text.setTypeface(typeFace);
+	        }
+    	}
 	public void setAccentColor(int color) {
 		this.accentColor = color;
         this.textColor = color;


### PR DESCRIPTION
This helper methods can be very useful if you want to use font awesome icons as text for the tabs. 

Example:

Typeface fontAwesome = Typeface.createFromAsset(getAssets(), "fonts/fontawesome-webfont.ttf");

```
    for (int i = 0; i < adapter.getCount(); i++) {

        MaterialTab tab = tabHost.newTab();
        tab.setText(adapter.getIcon(i));
        tab.setTabListener(this);
        tab.setTypeFace(fontAwesome);
        tabHost.addTab(tab);


    }
```
